### PR TITLE
Update solution for Visual Studio 2022 v18.3 compatibility

### DIFF
--- a/TaskManagerApi/TaskManagerApi.sln
+++ b/TaskManagerApi/TaskManagerApi.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.14.36623.8
+# Visual Studio Version 18
+VisualStudioVersion = 18.3.11505.172 d18.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TaskManagerApi", "TaskManagerApi.csproj", "{2B65DCF4-29F6-4CEF-9D73-0276F3B4BB50}"
 EndProject


### PR DESCRIPTION
Updated TaskManagerApi.sln to set VisualStudioVersion to 18.3, reflecting upgrade to Visual Studio 2022. No changes made to project references.