### PR TITLE
Update task query by UserId; change DB name in config 

### DIFF
--- a/TaskManagerApi.Application/Services/WorkItemService.cs
+++ b/TaskManagerApi.Application/Services/WorkItemService.cs
@@ -18,7 +18,7 @@ namespace TaskManagerApi.Application.Services
         }
         public async Task<IEnumerable<WorkItemDto>> GetAllTasksAsync(int id)
         {
-            var items = await _workItemRepository.GetAllByIdAsync(items => items.Id == id);
+            var items = await _workItemRepository.GetAllByIdAsync(items => items.UserId == id);
             return items.Select(i => new WorkItemDto
             {
                 Id = i.Id,

--- a/TaskManagerApi/appsettings.json
+++ b/TaskManagerApi/appsettings.json
@@ -10,7 +10,7 @@
   "AllowedHosts": "*",
   "AllowFrontend": [ "http://localhost:3000", "http://localhost:5173" ],
   "ConnectionStrings": {
-     "PgDefaultConnection": "Host=localhost;Port=5432;Database=taskmanager_qqiy;Username=postgres;Password=Sai@123;"
+     "PgDefaultConnection": "Host=localhost;Port=5432;Database=taskmanager;Username=postgres;Password=Sai@123;"
   },
   "Jwt": {
     "Key": "",


### PR DESCRIPTION
Updated GetAllTasksAsync to filter work items by UserId instead of Id, ensuring tasks are fetched per user. Also changed the PostgreSQL database name in appsettings.json from 'taskmanager_qqiy' to 'taskmanager'. 
#26 